### PR TITLE
Variable NEXP was not defined in the config files.

### DIFF
--- a/NVIDIA/benchmarks/unet3d/implementations/mxnet/config_DGXA100_conv-dali_13x8x1.sh
+++ b/NVIDIA/benchmarks/unet3d/implementations/mxnet/config_DGXA100_conv-dali_13x8x1.sh
@@ -34,6 +34,7 @@ export OMPI_MCA_btl=^openib
 ## System run parms
 export DGXNNODES=13
 export DGXSYSTEM=$(basename $(readlink -f ${BASH_SOURCE[0]}) | sed 's/^config_//' | sed 's/\.sh$//' )
+NEXP=${NEXP:-5} # Default number of times to run the benchmark
 WALLTIME_MINUTES=30
 export WALLTIME=$((${NEXP} * ${WALLTIME_MINUTES}))
 

--- a/NVIDIA/benchmarks/unet3d/implementations/mxnet/config_DGXA100_conv-dali_1x8x7.sh
+++ b/NVIDIA/benchmarks/unet3d/implementations/mxnet/config_DGXA100_conv-dali_1x8x7.sh
@@ -32,6 +32,7 @@ export OMPI_MCA_btl=^openib
 export DGXNNODES=1
 export DGXSYSTEM=$(basename $(readlink -f ${BASH_SOURCE[0]}) | sed 's/^config_//' | sed 's/\.sh$//' )
 WALLTIME_MINUTES=80
+NEXP=${NEXP:-5} # Default number of times to run the benchmark
 export WALLTIME=$((${NEXP} * ${WALLTIME_MINUTES}))
 
 ## System config params

--- a/NVIDIA/benchmarks/unet3d/implementations/mxnet/config_DGXA100_static_100x8x1.sh
+++ b/NVIDIA/benchmarks/unet3d/implementations/mxnet/config_DGXA100_static_100x8x1.sh
@@ -33,6 +33,7 @@ export HOROVOD_GROUPED_ALLREDUCES=1
 ## System run parms
 export DGXNNODES=100
 export DGXSYSTEM=$(basename $(readlink -f ${BASH_SOURCE[0]}) | sed 's/^config_//' | sed 's/\.sh$//' )
+NEXP=${NEXP:-5} # Default number of times to run the benchmark
 WALLTIME_MINUTES=24
 export WALLTIME=$((${NEXP} * ${WALLTIME_MINUTES}))
 


### PR DESCRIPTION
Variable NEXP was not defined in the config files. NEXP defines the default number of times to run the benchmark
Generally, NEXP is defined as 5 as any benchmark is run 5 times.